### PR TITLE
修复导航键不隐藏

### DIFF
--- a/library/src/main/java/cn/jzvd/Jzvd.java
+++ b/library/src/main/java/cn/jzvd/Jzvd.java
@@ -160,6 +160,10 @@ public abstract class Jzvd extends FrameLayout implements View.OnClickListener, 
                 //准备状态暂停后的
                 CURRENT_JZVD.startVideo();
             }
+            if (CURRENT_JZVD.screen == Jzvd.SCREEN_FULLSCREEN) {
+    			JZUtils.hideStatusBar(CURRENT_JZVD.jzvdContext);
+    			JZUtils.hideSystemUI(CURRENT_JZVD.jzvdContext);
+			}
         }
     }
 


### PR DESCRIPTION
解决了导航键在全屏模式下启动多任务返回播放不隐藏导航键的问题