### PR TITLE
底部拖动条视图消失时不应取消进度定时器

### DIFF
--- a/library/src/main/java/cn/jzvd/JzvdStd.java
+++ b/library/src/main/java/cn/jzvd/JzvdStd.java
@@ -947,7 +947,6 @@ public class JzvdStd extends Jzvd {
                 if (screen != SCREEN_TINY) {
                     bottomProgressBar.setVisibility(View.VISIBLE);
                 }
-                cancelProgressTimer();
             });
         }
     }


### PR DESCRIPTION
底部拖动条消失后，底部进度条依然可见，因此不应取消进度定时器。否则，一旦用户点击播放器界面后底部进度条进度不再更新
相关问题已经有提出过——https://github.com/Jzvd/JZVideo/issues/326
导致该问题的相关提交——https://github.com/Jzvd/JZVideo/pull/231