### PR TITLE
当在右侧上划屏幕的时候，增加声音会发生空指针异常

### DIFF
--- a/library/src/main/java/cn/jzvd/Jzvd.java
+++ b/library/src/main/java/cn/jzvd/Jzvd.java
@@ -468,6 +468,7 @@ public abstract class Jzvd extends FrameLayout implements View.OnClickListener, 
                             }
                         } else {//右侧改变声音
                             mChangeVolume = true;
+                            mAudioManager = (AudioManager) getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
                             mGestureDownVolume = mAudioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
                         }
                     }


### PR DESCRIPTION
全屏的情况下，当在右侧上划屏幕的时候，增加声音会发生空指针异常

![Snipaste_2024-02-28_17-12-42](https://github.com/Jzvd/JZVideo/assets/37319319/f7c6b8fb-ce53-41c4-9cb4-191fbf92d56d)
